### PR TITLE
docs: highlight prereqs TD3.1a et nettoyage titres flux

### DIFF
--- a/input/pagecontent/transaction_td02.md
+++ b/input/pagecontent/transaction_td02.md
@@ -53,7 +53,7 @@ Le LPS a vérifié les conditions d'accès de l'acteur de santé au DMP du patie
 
 Cette transaction n'a pas d'équivalent direct dans le profil MHD / PDSm, qui ne couvre pas la gestion du statut du DMP. Elle s'appuie sur l'API FHIR REST standard, en recherchant le patient par son INS sur l'endpoint `Patient`.
 
-#### Flux TD02-a — Requête
+#### Flux TD02 — Requête
 
 Le LPS effectue une recherche sur la ressource `Patient` en utilisant le paramètre `identifier` valorisé avec l'INS du patient.
 
@@ -70,7 +70,7 @@ Le système (OID) à utiliser selon le type d'INS :
 |-----------|------|-------------|-------------|
 | `identifier` | token | 1..1 | INS du patient, sous la forme `[système]\|[valeur]` |
 
-#### Flux TD02-b — Réponse
+#### Flux TD02 — Réponse
 
 En cas de succès, le système DMP retourne un code HTTP `200 OK` avec un `Bundle` de type `searchset`.
 

--- a/input/pagecontent/transaction_td2.1.md
+++ b/input/pagecontent/transaction_td2.1.md
@@ -40,7 +40,7 @@ La correspondance avec XDS est la suivante :
 | Association `RPLC` sur l'`entryUUID` du document X | `DocumentReference(Y).relatesTo.code = "replaces"` |
 | Mise à jour du statut du document X | `PATCH DocumentReference/X` avec `Parameters` FHIRPath : `replace DocumentReference.status → superseded` (slice `UpdateDocumentRefs`) |
 
-#### Flux TD2.1-a — Requête
+#### Flux TD2.1 — Requête
 
 ```
 POST [base] HTTP/1.1
@@ -64,7 +64,7 @@ Points clés sur le `DocumentReference` Y :
 
 Le document X est mis à jour via une opération `PATCH` FHIRPath (slice `UpdateDocumentRefs`) : seul le champ `status` est modifié à `superseded`. La ressource transmise est un `Parameters` contenant les opérations de patch, et non un DocumentReference complet.
 
-#### Flux TD2.1-b — Réponse
+#### Flux TD2.1 — Réponse
 
 En cas de succès, le système DMP retourne un `Bundle` de type `transaction-response` :
 

--- a/input/pagecontent/transaction_td2.md
+++ b/input/pagecontent/transaction_td2.md
@@ -38,7 +38,7 @@ Cette transaction peut être réalisée de deux façons selon le contexte d'impl
 
 #### Option A — ITI-105 : Publication simplifiée
 
-##### Flux TD2-a (ITI-105) — Requête
+##### Flux TD2 (ITI-105) — Requête
 
 Le LPS envoie directement un `DocumentReference` conforme au profil [PDSm_SimplifiedPublish](https://interop.esante.gouv.fr/ig/fhir/pdsm/StructureDefinition-pdsm-simplified-publish.html). Le contenu du document est embarqué dans `content.attachment.data` (base64).
 
@@ -48,7 +48,7 @@ Content-Type: application/fhir+json
 Accept: application/fhir+json
 ```
 
-##### Flux TD2-b (ITI-105) — Réponse
+##### Flux TD2 (ITI-105) — Réponse
 
 | Code HTTP | Signification |
 |-----------|--------------|
@@ -59,7 +59,7 @@ Accept: application/fhir+json
 
 #### Option B — ITI-65 : Lot de soumission complet
 
-##### Flux TD2-a (ITI-65) — Requête
+##### Flux TD2 (ITI-65) — Requête
 
 Le LPS envoie un `Bundle` de type `transaction` conforme au profil [PDSm_ComprehensiveProvideDocumentBundle](https://interop.esante.gouv.fr/ig/fhir/pdsm/StructureDefinition-pdsm-comprehensive-provide-document-bundle.html).
 
@@ -80,7 +80,7 @@ Le Bundle contient :
 
 Le `DocumentReference.content.attachment.url` référence la `Binary` du même Bundle via `urn:uuid:...`.
 
-##### Flux TD2-b (ITI-65) — Réponse
+##### Flux TD2 (ITI-65) — Réponse
 
 En cas de succès, le système DMP retourne un `Bundle` de type `transaction-response` :
 

--- a/input/pagecontent/transaction_td3.1a.md
+++ b/input/pagecontent/transaction_td3.1a.md
@@ -18,9 +18,14 @@ unique des document(s) sélectionnés. Cf. RG_3050.
 
 ### Entrée et prérequis
 
-L’INS du patient (EF_DMP11_01).
-Le statut « actif » du DMP du patient (EF_DMP12_01).
-L’autorisation d’accès au DMP du patient (EF_DMP04_01) au statut « valide ».
+<div style="background-color: #e8f4f8; border-left: 4px solid #0077be; padding: 10px; margin: 10px 0;">
+<b>Prérequis à vérifier avant d’exécuter cette transaction :</b>
+<ul>
+<li>L’INS du patient <code>(EF_DMP11_01)</code></li>
+<li>Le statut « actif » du DMP du patient <code>(EF_DMP12_01)</code></li>
+<li>L’autorisation d’accès au DMP du patient <code>(EF_DMP04_01)</code> au statut « valide »</li>
+</ul>
+</div>
 
 ### Sortie
 
@@ -30,7 +35,7 @@ La liste des documents consultables par l’utilisateur.
 
 TD3.1a correspond à la transaction **[ITI-67 Find Document References](https://interop.esante.gouv.fr/ig/fhir/pdsm/st_recherche.html)** du profil PDSm. Elle permet au LPS de rechercher les fiches (`DocumentReference`) du DMP d'un patient à partir de son INS et de critères optionnels.
 
-#### Flux TD3.1a-a — Requête
+#### Flux TD3.1a — Requête
 
 Le LPS effectue une recherche sur la ressource `DocumentReference` en utilisant le paramètre `patient.identifier` valorisé avec l'INS du patient.
 
@@ -59,7 +64,7 @@ Accept: application/fhir+json
 
 > **Note :** Le statut du DMP et l'autorisation d'accès ne sont pas des paramètres de la requête ITI-67. Ces prérequis sont vérifiés en amont (via TD02) et gérés par la couche d'autorisation du système DMP, en dehors du périmètre de cette transaction.
 
-#### Flux TD3.1a-b — Réponse
+#### Flux TD3.1a — Réponse
 
 En cas de succès, le système DMP retourne un code HTTP `200 OK` avec un `Bundle` de type `searchset` contenant zéro ou plusieurs ressources `DocumentReference`.
 

--- a/input/pagecontent/transaction_td3.1a.md
+++ b/input/pagecontent/transaction_td3.1a.md
@@ -18,14 +18,9 @@ unique des document(s) sélectionnés. Cf. RG_3050.
 
 ### Entrée et prérequis
 
-<div style="background-color: #e8f4f8; border-left: 4px solid #0077be; padding: 10px; margin: 10px 0;">
-<b>Prérequis à vérifier avant d’exécuter cette transaction :</b>
-<ul>
-<li>L’INS du patient <code>(EF_DMP11_01)</code></li>
-<li>Le statut « actif » du DMP du patient <code>(EF_DMP12_01)</code></li>
-<li>L’autorisation d’accès au DMP du patient <code>(EF_DMP04_01)</code> au statut « valide »</li>
-</ul>
-</div>
+L’INS du patient (EF_DMP11_01).
+Le statut « actif » du DMP du patient (EF_DMP12_01).
+L’autorisation d’accès au DMP du patient (EF_DMP04_01) au statut « valide ».
 
 ### Sortie
 
@@ -48,7 +43,7 @@ Accept: application/fhir+json
 
 | Paramètre FHIR | Type | Cardinalité | Métadonnée XDS | Description |
 |----------------|------|-------------|----------------|-------------|
-| `patient.identifier` | token | 1..1 | `patientID` | INS du patient (`[système]\|[valeur]`) |
+| **`patient.identifier`** | token | 1..1 | `patientID` | INS du patient (`[système]\|[valeur]`) |
 | `status` | token | 0..1 | `availabilityStatus` | `current` (approuvé) ou `superseded` (déprécié) |
 | `type` | token | 0..* | `type` | Type du document (JDV_J07-XdsTypeCode-CISIS) |
 | `category` | token | 0..* | `class` | Classe du document (JDV_J06-XdsClassCode-CISIS) |

--- a/input/pagecontent/transaction_td3.1b.md
+++ b/input/pagecontent/transaction_td3.1b.md
@@ -28,7 +28,7 @@ L’identifiant unique du document dans le système DMP (entryUUID).
 
 TD3.1b correspond à la transaction **[ITI-67 Find Document References](https://interop.esante.gouv.fr/ig/fhir/pdsm/st_recherche.html)** du profil PDSm, utilisée ici avec le paramètre `identifier` pour retrouver un document précis à partir de son identifiant local LPS (`uniqueId`).
 
-#### Flux TD3.1b-a — Requête
+#### Flux TD3.1b — Requête
 
 ```
 GET [base]/DocumentReference?patient.identifier=[systeme-INS]|[valeur-INS]&identifier=[systeme-uniqueId]|[valeur-uniqueId] HTTP/1.1
@@ -44,7 +44,7 @@ Accept: application/fhir+json
 
 > **Note :** Le statut du DMP et l’autorisation d’accès sont des prérequis vérifiés en amont (via TD02) et gérés par la couche d’autorisation du système DMP, en dehors du périmètre de cette transaction.
 
-#### Flux TD3.1b-b — Réponse
+#### Flux TD3.1b — Réponse
 
 En cas de succès, le système DMP retourne un code HTTP `200 OK` avec un `Bundle` de type `searchset`.
 

--- a/input/pagecontent/transaction_td3.2.md
+++ b/input/pagecontent/transaction_td3.2.md
@@ -29,7 +29,7 @@ Les documents affichés par le LPS.
 
 TD3.2 correspond à la transaction **[ITI-68 Retrieve Document](https://interop.esante.gouv.fr/ig/fhir/pdsm/st_consultation.html)** du profil PDSm. Le LPS utilise l'URL présente dans `DocumentReference.content.attachment.url` (obtenue via TD3.1a) pour télécharger le contenu binaire du document.
 
-#### Flux TD3.2-a — Requête
+#### Flux TD3.2 — Requête
 
 ```
 GET [DocumentReference.content.attachment.url] HTTP/1.1
@@ -45,7 +45,7 @@ GET [base]/Binary/[id] HTTP/1.1
 Accept: application/fhir+json
 ```
 
-#### Flux TD3.2-b — Réponse
+#### Flux TD3.2 — Réponse
 
 | Code HTTP | Signification |
 |-----------|--------------|

--- a/input/pagecontent/transaction_td3.3a.md
+++ b/input/pagecontent/transaction_td3.3a.md
@@ -40,7 +40,7 @@ L'`entryUUID` XDS correspond à l'`id` logique de la ressource `DocumentReferenc
 
 > **Question ouverte** — L'utilisation de `DocumentReference.securityLabel` est-elle suffisante pour représenter le masquage aux professionnels dans le contexte DMP ? Une analyse plus approfondie pourrait être nécessaire, notamment pour évaluer la pertinence d'un profilage de la ressource `Consent` (qui permet d'exprimer des politiques d'accès différenciées par acteur). Ce point est à trancher lors des travaux d'alignement avec les exigences DMP.
 
-#### Flux TD3.3a-a — Requête (masquage)
+#### Flux TD3.3a — Requête (masquage)
 
 Le PATCH s'effectue par l'identifiant métier du document (`uniqueId` XDS → `DocumentReference.identifier`) :
 
@@ -70,7 +70,7 @@ Corps de la requête (JSON Patch) :
 ]
 ```
 
-#### Flux TD3.3a-a — Requête (démasquage)
+#### Flux TD3.3a — Requête (démasquage)
 
 ```
 PATCH [base]/DocumentReference?identifier=[système]|[uniqueId] HTTP/1.1
@@ -96,7 +96,7 @@ Accept: application/fhir+json
 ]
 ```
 
-#### Flux TD3.3a-b — Réponse
+#### Flux TD3.3a — Réponse
 
 | Code HTTP | Signification |
 |-----------|--------------|

--- a/input/pagecontent/transaction_td3.3b.md
+++ b/input/pagecontent/transaction_td3.3b.md
@@ -42,7 +42,7 @@ Par défaut, un document soumis dans le DMP est visible au patient. Un professio
 
 > **Question ouverte** — L'utilisation de `DocumentReference.securityLabel` est-elle suffisante pour représenter la visibilité patient dans le contexte DMP ? Une analyse plus approfondie pourrait être nécessaire, notamment pour évaluer la pertinence d'un profilage de la ressource `Consent` (qui permet d'exprimer des politiques d'accès différenciées par catégorie d'acteur, dont le patient lui-même). Ce point est à trancher lors des travaux d'alignement avec les exigences DMP.
 
-#### Flux TD3.3b-a — Requête (masquage patient)
+#### Flux TD3.3b — Requête (masquage patient)
 
 Le PATCH s'effectue par l'identifiant métier du document (`uniqueId` XDS → `DocumentReference.identifier`) :
 
@@ -72,7 +72,7 @@ Corps de la requête (JSON Patch) :
 ]
 ```
 
-#### Flux TD3.3b-a — Requête (visibilité patient rétablie)
+#### Flux TD3.3b — Requête (visibilité patient rétablie)
 
 ```
 PATCH [base]/DocumentReference?identifier=[système]|[uniqueId] HTTP/1.1
@@ -98,7 +98,7 @@ Accept: application/fhir+json
 ]
 ```
 
-#### Flux TD3.3b-b — Réponse
+#### Flux TD3.3b — Réponse
 
 | Code HTTP | Signification |
 |-----------|--------------|

--- a/input/pagecontent/transaction_td3.3c.md
+++ b/input/pagecontent/transaction_td3.3c.md
@@ -35,7 +35,7 @@ En FHIR, la suppression d'un document DMP se traduit par la mise à jour de `Doc
 |-----------|---------------------|--------|
 | Supprimer | `DocumentReference.status` | `entered-in-error` |
 
-#### Flux TD3.3c-a — Requête
+#### Flux TD3.3c — Requête
 
 Le PATCH s'effectue par l'identifiant métier du document (`uniqueId` XDS → `DocumentReference.identifier`) :
 
@@ -57,7 +57,7 @@ Corps de la requête (JSON Patch) :
 ]
 ```
 
-#### Flux TD3.3c-b — Réponse
+#### Flux TD3.3c — Réponse
 
 | Code HTTP | Signification |
 |-----------|--------------|

--- a/input/pagecontent/transaction_td3.3d.md
+++ b/input/pagecontent/transaction_td3.3d.md
@@ -35,7 +35,7 @@ TD3.3d correspond aux flux **[Flux 03 / Flux 04 — Mise à jour des métadonné
 | Archiver | `Deprecated` | `DocumentReference.status` | `superseded` |
 | Désarchiver | `Approved` | `DocumentReference.status` | `current` |
 
-#### Flux TD3.3d-a — Requête (archivage)
+#### Flux TD3.3d — Requête (archivage)
 
 Le PATCH s'effectue par l'identifiant métier du document (`uniqueId` XDS → `DocumentReference.identifier`) :
 
@@ -57,7 +57,7 @@ Corps de la requête (JSON Patch) :
 ]
 ```
 
-#### Flux TD3.3d-a — Requête (désarchivage)
+#### Flux TD3.3d — Requête (désarchivage)
 
 ```
 PATCH [base]/DocumentReference?identifier=[système]|[uniqueId] HTTP/1.1
@@ -81,7 +81,7 @@ Si un document a été remplacé par une version ultérieure avant son archivage
 Il est recommandé de vérifier l'existence d'un document remplaçant (via <code>DocumentReference.relatesTo</code> avec code <code>replaces</code>) avant d'effectuer le désarchivage, et de gérer ce cas en aval (ex. archiver à nouveau le document remplacé ou alerter l'utilisateur).
 </div>
 
-#### Flux TD3.3d-b — Réponse
+#### Flux TD3.3d — Réponse
 
 | Code HTTP | Signification |
 |-----------|--------------|


### PR DESCRIPTION
## Description des changements

* Mise en valeur des trois prérequis de la section « Entrée et prérequis » de TD3.1a dans un encart bleu (INS du patient, statut actif du DMP, autorisation d'accès)
* Suppression des suffixes `-a` / `-b` dans tous les titres de type `Flux TDxx-a — Requête` sur l'ensemble des pages de transaction (TD02, TD2, TD2.1, TD3.1a, TD3.1b, TD3.2, TD3.3a, TD3.3b, TD3.3c, TD3.3d)

## Type de changement

- [ ] Nouveau contenu (profil, extension, page, exemple)
- [ ] Correction (erreur dans un profil, une page, une dépendance)
- [x] Refactoring (pas de changement fonctionnel)
- [ ] Release

## Checklist

- [x] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
- [ ] `change-log.md` mis à jour
- [x] La branche est à jour avec `main`

## Preview

https://ansforge.github.io/IG-FHIR-PDSM4DMP-EEDS/nr-highlight-prereqs-td3.1a/ig