### PR TITLE
docs: split menu Transaction DMP Patient / Document and remove stub pages

### DIFF
--- a/input/pagecontent/annexe_dates_xds_fhir.md
+++ b/input/pagecontent/annexe_dates_xds_fhir.md
@@ -1,10 +1,8 @@
 <!-- Cf discussions https://github.com/IHE/ITI.MHD/pull/234 -->
 
-### Comparatif des dates XDS et FHIR
-
 Le modèle XDS distingue plusieurs dates portant des sémantiques précises. Leur transposition en FHIR/MHD nécessite de bien comprendre à quoi correspond chaque élément.
 
-#### DocumentEntry / DocumentReference
+### DocumentEntry / DocumentReference
 
 | Date XDS | Type | Description | Équivalent FHIR |
 |----------|------|-------------|-----------------|
@@ -19,13 +17,13 @@ Le modèle XDS distingue plusieurs dates portant des sémantiques précises. Leu
 
 > **Note :** `DocumentReference.meta.lastUpdated` n'a pas d'équivalent XDS — c'est une métadonnée propre au serveur FHIR, mise à jour à chaque modification de la ressource (ex. : changement de statut lors d'un remplacement de document).
 
-#### SubmissionSet / List (SubmissionSet PDSm)
+### SubmissionSet / List (SubmissionSet PDSm)
 
 | Date XDS | Type | Description | Équivalent FHIR |
 |----------|------|-------------|-----------------|
 | `submissionTime` | DTM | Date et heure de soumission du lot au registre DMP. | `List.date` |
 
-#### Récapitulatif visuel
+### Récapitulatif visuel
 
 ```
 Cycle de vie d'un document dans le DMP
@@ -45,7 +43,7 @@ Cycle de vie d'un document dans le DMP
                                                     meta.lastUpdated
 ```
 
-#### Points d'attention pour l'implémentation
+### Points d'attention pour l'implémentation
 
 - **`creationTime` ≠ `submissionTime`** : un document peut être créé (signé) plusieurs jours avant d'être soumis au DMP. Le LPS doit renseigner `DocumentReference.date` avec la date de création réelle du document, pas la date d'envoi.
 - **`serviceStartTime` obligatoire** : `DocumentReference.context.period.start` est requis par le profil PDSm. Il correspond à la date de l'acte médical — date de consultation, date de l'examen, etc.

--- a/input/pagecontent/annexe_dates_xds_fhir.md
+++ b/input/pagecontent/annexe_dates_xds_fhir.md
@@ -1,3 +1,5 @@
+<!-- Cf discussions https://github.com/IHE/ITI.MHD/pull/234 -->
+
 ### Comparatif des dates XDS et FHIR
 
 Le modèle XDS distingue plusieurs dates portant des sémantiques précises. Leur transposition en FHIR/MHD nécessite de bien comprendre à quoi correspond chaque élément.

--- a/input/pagecontent/annexe_identifiants_xds_fhir.md
+++ b/input/pagecontent/annexe_identifiants_xds_fhir.md
@@ -1,8 +1,6 @@
-### Comparatif des identifiants XDS et FHIR
-
 Dans le contexte DMP, les mêmes documents sont manipulés à travers deux modèles de métadonnées : le modèle XDS (utilisé par le CI-SIS et les spécifications DMP historiques) et le modèle FHIR/MHD (utilisé par PDSm). Cette page recense les identifiants de chaque modèle et leurs équivalents.
 
-#### DocumentEntry / DocumentReference
+### DocumentEntry / DocumentReference
 
 | Identifiant XDS | Type | Description | Équivalent FHIR |
 |-----------------|------|-------------|-----------------|
@@ -17,7 +15,7 @@ Dans le contexte DMP, les mêmes documents sont manipulés à travers deux modè
 
 > **Note :** Dans le contexte DMP, `uniqueId` correspond à l'identifiant que le LPS attribue au document au moment de sa création. C'est l'identifiant que le LPS connaît localement. L'`entryUUID`, en revanche, est attribué par le registre DMP lors de la soumission — le LPS doit l'obtenir via TD3.1a ou TD3.1b pour pouvoir ensuite modifier ou supprimer le document.
 
-#### SubmissionSet / List (SubmissionSet PDSm)
+### SubmissionSet / List (SubmissionSet PDSm)
 
 | Identifiant XDS | Type | Description | Équivalent FHIR |
 |-----------------|------|-------------|-----------------|
@@ -27,7 +25,7 @@ Dans le contexte DMP, les mêmes documents sont manipulés à travers deux modè
 | `patientId` | CX | Identifiant du patient. | `List.subject` → `Patient.identifier` |
 | `sourcePatientId` | CX | Identifiant local du patient chez la source. | Extension `ihe-sourcePatientId` sur `List` |
 
-#### Folder / List (Folder PDSm)
+### Folder / List (Folder PDSm)
 
 | Identifiant XDS | Type | Description | Équivalent FHIR |
 |-----------------|------|-------------|-----------------|
@@ -35,7 +33,7 @@ Dans le contexte DMP, les mêmes documents sont manipulés à travers deux modè
 | `uniqueId` | OID / UUID | Identifiant unique du classeur attribué par le producteur. | `List.identifier` |
 | `patientId` | CX | Identifiant du patient. | `List.subject` → `Patient.identifier` |
 
-#### Récapitulatif : entryUUID vs uniqueId dans le contexte DMP
+### Récapitulatif : entryUUID vs uniqueId dans le contexte DMP
 
 Ces deux identifiants sont les plus fréquemment confondus. Le tableau ci-dessous résume leurs différences essentielles.
 

--- a/input/pagecontent/transaction_1.md
+++ b/input/pagecontent/transaction_1.md
@@ -1,5 +1,0 @@
-### Entrée
-
-### Sortie
-
-### Exemple

--- a/input/pagecontent/transaction_2.md
+++ b/input/pagecontent/transaction_2.md
@@ -1,5 +1,0 @@
-### Entrée
-
-### Sortie
-
-### Exemple

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -90,8 +90,9 @@ pages:
 
 menu:
     Accueil: index.html
-    Transactions DMP:
+    Transaction DMP Patient:
         "TD02 - Valider existence DMP": transaction_td02.html
+    Transaction DMP Document:
         "TD2 - Soumettre des documents": transaction_td2.html
         "TD2.1 - Remplacer un document": transaction_td2.1.html
         "TD3.1a - Lister les documents": transaction_td3.1a.html


### PR DESCRIPTION
## Description des changements

* Séparation du menu en deux entrées : « Transaction DMP Patient » (TD02, TD3.3b) et « Transaction DMP Document » (TD2, TD2.1, TD3.1a, TD3.1b, TD3.2, TD3.3a, TD3.3c, TD3.3d)
* Suppression des pages stub vides `transaction_1.md` et `transaction_2.md`

## Type de changement

- [ ] Nouveau contenu (profil, extension, page, exemple)
- [ ] Correction (erreur dans un profil, une page, une dépendance)
- [x] Refactoring (pas de changement fonctionnel)
- [ ] Release

## Checklist

- [x] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
- [ ] `change-log.md` mis à jour
- [x] La branche est à jour avec `main`

## Preview

https://ansforge.github.io/IG-FHIR-PDSM4DMP-EEDS/nr-update-menu/ig