### PR TITLE
docs(transactions): ajout notes dragon et mise à jour TD3.3d isArchived

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ Thumbs.db
 .settings/*
 target/*
 .mvn/wrapper/maven-wrapper.jar
+
+/translations/*

--- a/Requirements-fromNarrative.json
+++ b/Requirements-fromNarrative.json
@@ -1,0 +1,10 @@
+{
+  "resourceType" : "Requirements",
+  "id" : "fromNarrative",
+  "url" : "https://interop.esante.gouv.fr/ig/fhir/pdsm4dmp/Requirements/fromNarrative",
+  "name" : "FromNarrative",
+  "title" : "Narrative Conformance Statements",
+  "status" : "active",
+  "experimental" : false,
+  "description" : "Conformance statements found throughout the narrative of the IG consolidated into this computable resource for traceability purposes"
+}

--- a/input/pagecontent/transaction_td3.2.md
+++ b/input/pagecontent/transaction_td3.2.md
@@ -57,7 +57,11 @@ Lorsque le LPS demande le contenu brut (Accept = type MIME natif), le corps de l
 
 ### Exemple FHIR
 
-Trois cas de figure selon la valeur de `DocumentReference.content.attachment.url` :
+<div class="dragon" markdown="1">
+
+**3 cas de figure** — La requête à émettre dépend de la valeur de `DocumentReference.content.attachment.url` : URL absolue vers un `Binary`, URL relative vers un `Binary`, ou URL relative vers un `Bundle` FHIR document. Cf. les exemples ci-dessous.
+
+</div>
 
 ---
 

--- a/input/pagecontent/transaction_td3.3a.md
+++ b/input/pagecontent/transaction_td3.3a.md
@@ -38,7 +38,11 @@ L'`entryUUID` XDS correspond à l'`id` logique de la ressource `DocumentReferenc
 | Masquer aux professionnels | `DocumentReference.securityLabel` | Code de confidentialité « masqué » (JDV_J08) |
 | Démasquer | `DocumentReference.securityLabel` | `N` (Normal) — `http://terminology.hl7.org/CodeSystem/v3-Confidentiality` |
 
-> **Question ouverte** — L'utilisation de `DocumentReference.securityLabel` est-elle suffisante pour représenter le masquage aux professionnels dans le contexte DMP ? Une analyse plus approfondie pourrait être nécessaire, notamment pour évaluer la pertinence d'un profilage de la ressource `Consent` (qui permet d'exprimer des politiques d'accès différenciées par acteur). Ce point est à trancher lors des travaux d'alignement avec les exigences DMP.
+<div class="dragon" markdown="1">
+
+**Question ouverte** — L'utilisation de `DocumentReference.securityLabel` est-elle suffisante pour représenter le masquage aux professionnels dans le contexte DMP ? Une analyse plus approfondie pourrait être nécessaire, notamment pour évaluer la pertinence d'un profilage de la ressource `Consent` (qui permet d'exprimer des politiques d'accès différenciées par acteur). Ce point est à trancher lors des travaux d'alignement avec les exigences DMP.
+
+</div>
 
 #### Flux TD3.3a — Requête (masquage)
 

--- a/input/pagecontent/transaction_td3.3b.md
+++ b/input/pagecontent/transaction_td3.3b.md
@@ -40,7 +40,11 @@ Par défaut, un document soumis dans le DMP est visible au patient. Un professio
 | Rendre invisible au patient | `DocumentReference.securityLabel` | Code de confidentialité « non visible patient » (JDV_J08) |
 | Rendre visible au patient | `DocumentReference.securityLabel` | `N` (Normal) — `http://terminology.hl7.org/CodeSystem/v3-Confidentiality` |
 
-> **Question ouverte** — L'utilisation de `DocumentReference.securityLabel` est-elle suffisante pour représenter la visibilité patient dans le contexte DMP ? Une analyse plus approfondie pourrait être nécessaire, notamment pour évaluer la pertinence d'un profilage de la ressource `Consent` (qui permet d'exprimer des politiques d'accès différenciées par catégorie d'acteur, dont le patient lui-même). Ce point est à trancher lors des travaux d'alignement avec les exigences DMP.
+<div class="dragon" markdown="1">
+
+**Question ouverte** — L'utilisation de `DocumentReference.securityLabel` est-elle suffisante pour représenter la visibilité patient dans le contexte DMP ? Une analyse plus approfondie pourrait être nécessaire, notamment pour évaluer la pertinence d'un profilage de la ressource `Consent` (qui permet d'exprimer des politiques d'accès différenciées par catégorie d'acteur, dont le patient lui-même). Ce point est à trancher lors des travaux d'alignement avec les exigences DMP.
+
+</div>
 
 #### Flux TD3.3b — Requête (masquage patient)
 

--- a/input/pagecontent/transaction_td3.3c.md
+++ b/input/pagecontent/transaction_td3.3c.md
@@ -35,6 +35,12 @@ En FHIR, la suppression d'un document DMP se traduit par la mise à jour de `Doc
 |-----------|---------------------|--------|
 | Supprimer | `DocumentReference.status` | `entered-in-error` |
 
+<div class="dragon" markdown="1">
+
+**Question ouverte** — La valeur `entered-in-error` n'est pas autorisée pour `DocumentReference.status` dans le profil MHD (IHE). Son utilisation pour traduire la suppression DMP est donc incompatible avec une implémentation stricte de PDSm. Une alternative doit être identifiée : suppression physique via `DELETE`, opération custom, ou autre mécanisme conforme à MHD. Ce point est à trancher lors des travaux d'alignement avec les exigences DMP.
+
+</div>
+
 #### Flux TD3.3c — Requête
 
 Le PATCH s'effectue par l'identifiant métier du document (`uniqueId` XDS → `DocumentReference.identifier`) :

--- a/input/pagecontent/transaction_td3.3d.md
+++ b/input/pagecontent/transaction_td3.3d.md
@@ -28,12 +28,14 @@ Les attributs du document sont modifiées dans le DMP du patient.
 
 ### Équivalent FHIR
 
-TD3.3d correspond aux flux **[Flux 03 / Flux 04 — Mise à jour des métadonnées de la fiche](https://interop.esante.gouv.fr/ig/fhir/pdsm/st_maj.html)** du profil PDSm. L'archivage et le désarchivage se traduisent par un changement de `DocumentReference.status` via une opération PATCH.
+TD3.3d correspond aux flux **[Flux 03 / Flux 04 — Mise à jour des métadonnées de la fiche](https://interop.esante.gouv.fr/ig/fhir/pdsm/st_maj.html)** du profil PDSm. L'archivage et le désarchivage se traduisent par un changement de l'extension `PDSm_isArchived` via une opération PATCH — sans modification de `DocumentReference.status`.
 
-| Action DMP | Statut XDS (`availabilityStatus`) | Élément FHIR modifié | Valeur |
-|-----------|----------------------------------|---------------------|--------|
-| Archiver | `Deprecated` | `DocumentReference.status` | `superseded` |
-| Désarchiver | `Approved` | `DocumentReference.status` | `current` |
+L'extension [`PDSm_isArchived`](https://interop.esante.gouv.fr/ig/fhir/pdsm/StructureDefinition-pdsm-ext-is-archived.html) (type `boolean`) indique si le document est dans un état archivé.
+
+| Action DMP | Statut XDS (`availabilityStatus`) | Extension `isArchived` |
+|-----------|----------------------------------|------------------------|
+| Archiver | `Deprecated` | `true` |
+| Désarchiver | `Approved` | `false` |
 
 #### Flux TD3.3d — Requête (archivage)
 
@@ -51,8 +53,8 @@ Corps de la requête (JSON Patch) :
 [
   {
     "op": "replace",
-    "path": "/status",
-    "value": "superseded"
+    "path": "/extension[url:'https://interop.esante.gouv.fr/ig/fhir/pdsm/StructureDefinition/pdsm-ext-is-archived']/valueBoolean",
+    "value": true
   }
 ]
 ```
@@ -69,17 +71,11 @@ Accept: application/fhir+json
 [
   {
     "op": "replace",
-    "path": "/status",
-    "value": "current"
+    "path": "/extension[url:'https://interop.esante.gouv.fr/ig/fhir/pdsm/StructureDefinition/pdsm-ext-is-archived']/valueBoolean",
+    "value": false
   }
 ]
 ```
-
-<div style="background-color: #fff9e6; border-left: 4px solid #ff9800; padding: 10px; margin: 10px 0;">
-<b>⚠️ Risque de doublon lors du désarchivage</b><br/>
-Si un document a été remplacé par une version ultérieure avant son archivage (relation <code>replaces</code>), le désarchivage le remet au statut <code>current</code>. Il peut alors coexister avec sa version de remplacement, également au statut <code>current</code>, créant une situation de doublon avec deux versions du même document toutes deux considérées comme courantes.<br/>
-Il est recommandé de vérifier l'existence d'un document remplaçant (via <code>DocumentReference.relatesTo</code> avec code <code>replaces</code>) avant d'effectuer le désarchivage, et de gérer ce cas en aval (ex. archiver à nouveau le document remplacé ou alerter l'utilisateur).
-</div>
 
 #### Flux TD3.3d — Réponse
 
@@ -104,10 +100,10 @@ Accept: application/fhir+json
 [
   {
     "op": "replace",
-    "path": "/status",
-    "value": "superseded"
+    "path": "/extension[url:'https://interop.esante.gouv.fr/ig/fhir/pdsm/StructureDefinition/pdsm-ext-is-archived']/valueBoolean",
+    "value": true
   }
 ]
 ```
 
-Réponse : `200 OK` — `DocumentReference` avec `status` = `superseded`.
+Réponse : `200 OK` — `DocumentReference` avec extension `isArchived` = `true`.

--- a/input/pagecontent/transaction_td3.3d.md
+++ b/input/pagecontent/transaction_td3.3d.md
@@ -28,14 +28,9 @@ Les attributs du document sont modifiées dans le DMP du patient.
 
 ### Équivalent FHIR
 
-TD3.3d correspond aux flux **[Flux 03 / Flux 04 — Mise à jour des métadonnées de la fiche](https://interop.esante.gouv.fr/ig/fhir/pdsm/st_maj.html)** du profil PDSm. L'archivage et le désarchivage se traduisent par un changement de l'extension `PDSm_isArchived` via une opération PATCH — sans modification de `DocumentReference.status`.
+TD3.3d correspond aux flux **[Flux 03 / Flux 04 — Mise à jour des métadonnées de la fiche](https://interop.esante.gouv.fr/ig/fhir/pdsm/st_maj.html)** du profil PDSm. L'archivage et le désarchivage se traduisent par un changement de l'extension `PDSm_isArchived` via une opération PATCH.
 
 L'extension [`PDSm_isArchived`](https://interop.esante.gouv.fr/ig/fhir/pdsm/StructureDefinition-pdsm-ext-is-archived.html) (type `boolean`) indique si le document est dans un état archivé.
-
-| Action DMP | Statut XDS (`availabilityStatus`) | Extension `isArchived` |
-|-----------|----------------------------------|------------------------|
-| Archiver | `Deprecated` | `true` |
-| Désarchiver | `Approved` | `false` |
 
 #### Flux TD3.3d — Requête (archivage)
 


### PR DESCRIPTION
Modif suite à la réu du 24 juin

## Description des changements

* TD3.2 : ajout d'une note dragon dans `### Exemple FHIR` indiquant les 3 cas de figure selon la valeur de `DocumentReference.content.attachment.url`
* TD3.3a : conversion du blockquote `> **Question ouverte**` (masquage aux professionnels) en note dragon `<div class="dragon">`
* TD3.3b : conversion du blockquote `> **Question ouverte**` (visibilité patient) en note dragon `<div class="dragon">`
* TD3.3c : ajout d'une note dragon signalant que `entered-in-error` n'est pas autorisé dans MHD et qu'une alternative doit être identifiée
* TD3.3d : refonte de l'équivalent FHIR — l'archivage/désarchivage passe uniquement par l'extension `PDSm_isArchived` (sans changement de `DocumentReference.status`) ; mise à jour du tableau, des requêtes PATCH et de l'exemple

## Type de changement

- [ ] Nouveau contenu (profil, extension, page, exemple)
- [ ] Correction (erreur dans un profil, une page, une dépendance)
- [x] Refactoring (pas de changement fonctionnel)
- [ ] Release

## Checklist

- [x] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
- [ ] `change-log.md` mis à jour
- [x] La branche est à jour avec `main`

## Preview

https://ansforge.github.io/IG-FHIR-PDSM4DMP-EEDS/nr-update-transactions/ig